### PR TITLE
Bump Go version to `1.23`

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.x
+        go-version: 1.23.x
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.x
+        go-version: 1.23.x
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.x
+        go-version: 1.23.x
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4


### PR DESCRIPTION
Bump Go to `1.23` in GitHub Actions for tests and builds.
